### PR TITLE
Update the clang-format

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -12,7 +12,7 @@ if [ ! -f ".clang-format" ]; then
 
 	echo "Generate clang format configuration file"
 	clang-format -style=Google -dump-config > .clang-format 
-    sed -i 's/SortIncludes:    true/SortIncludes:    false/g' .clang-format
+    sed -i 's/SortIncludes:    CaseSensitive/SortIncludes:    Never/g' .clang-format
 fi
 
 echo "Formating header files"


### PR DESCRIPTION
The option for not sorting the header files was renamed from `false` to` never.
`

